### PR TITLE
Bump up the CsvHelper

### DIFF
--- a/sandbox/Quicksilver/EPiServer.Reference.Commerce.Site/EPiServer.Reference.Commerce.Site.csproj
+++ b/sandbox/Quicksilver/EPiServer.Reference.Commerce.Site/EPiServer.Reference.Commerce.Site.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <None Include="wwwroot\**\*.*" />
     <EmbeddedResource Include="lang\**\*" />
-    <PackageReference Include="CsvHelper" Version="27.2.1" />
+    <PackageReference Include="CsvHelper" Version="30.0.1" />
     <PackageReference Include="EPiServer.Commerce" Version="$(CommerceCoreVersion)" />
     <PackageReference Include="EPiServer.Personalization.Commerce" Version="$(CommerceTrackingeVersion)" />
     <PackageReference Include="Serilog" Version="$(SerilogVersion)" />

--- a/src/Geta.Optimizely.ProductFeed.Csv/Geta.Optimizely.ProductFeed.Csv.csproj
+++ b/src/Geta.Optimizely.ProductFeed.Csv/Geta.Optimizely.ProductFeed.Csv.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="27.2.1" />
+    <PackageReference Include="CsvHelper" Version="30.0.1" />
     <PackageReference Include="EPiServer.Commerce.Core" Version="14.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.6" />


### PR DESCRIPTION
Identified a problem with the Csv feed generator when the base project use the latest version of CsvHelper.

![image](https://user-images.githubusercontent.com/5949747/216295244-77d1ede0-1499-4426-96b4-bf18276fe9ab.png)
