### PR TITLE
Refactor SerializeEntry to handle collections in CsvFeedExporter

### DIFF
--- a/src/Geta.Optimizely.ProductFeed.Csv/CsvFeedExporter.cs
+++ b/src/Geta.Optimizely.ProductFeed.Csv/CsvFeedExporter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Geta Digital. All rights reserved.
 // Licensed under Apache-2.0. See the LICENSE file in the project root for more information
 
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -30,8 +31,17 @@ public class CsvFeedExporter<TEntity>(CsvFeedDescriptor<TEntity> descriptor) : A
 
     public override byte[] SerializeEntry(object value, CancellationToken cancellationToken)
     {
-        _writer.WriteRecord(value);
-        _writer.NextRecord();
+        // Handle collections (e.g., IEnumerable<CsvEntry>) by writing all records.
+        // Use non-generic IEnumerable to avoid generic invariance issues.
+        if (value is IEnumerable enumerable && value is not string)
+        {
+            _writer.WriteRecords(enumerable);
+        }
+        else
+        {
+            _writer.WriteRecord(value);
+            _writer.NextRecord();
+        }
 
         return [];
     }


### PR DESCRIPTION
Adds the ability to write collections to the CSV. This is especially helpful if you need to write multiple lines for a single Entity (ie. entity that have multiple assets/images)